### PR TITLE
[MOD-88][Fix] Don't show errors until user clicks submit

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -172,6 +172,8 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     editMode: false, // Edit mode is false by default.
     shareButtonDisabled: false, // Relevant in Add mode - flag prevents users from sending multiple requests to server
 
+    attemptedSubmit: false, // True when user has tried to submit with validation errors
+
     isTopLevelNode: Ember.computed.not('node.parent.id'),
 
     hasFile: Ember.computed.or('file', 'selectedFile'),
@@ -219,7 +221,8 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
             subjectsList: Ember.A(),
             availableLicenses: Ember.A(),
             applyLicense: false,
-            newNode: false
+            newNode: false,
+            attemptedSubmit: false,
         }));
     },
 
@@ -257,6 +260,11 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
 
     // Preprint can be published once all required sections have been saved.
     allSectionsValid: Ember.computed.and('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid'),
+
+    // Are there validation errors which should be displayed right now?
+    showValidationErrors: Ember.computed('attemptedSubmit', 'allSectionsValid', function() {
+        return this.get('attemptedSubmit') && !this.get('allSectionsValid');
+    }),
 
     ////////////////////////////////////////////////////
     // Fields used in the "upload" section of the form.
@@ -997,14 +1005,24 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
           Submit tab actions
          */
         toggleSharePreprintModal() {
-            // Toggles display of share preprint modal
-            Ember.get(this, 'metrics')
-                .trackEvent({
-                    category: 'button',
-                    action: 'click',
-                    label: 'Submit - Open Share Preprint Modal'
-                });
-            this.toggleProperty('showModalSharePreprint');
+            if (this.get('allSectionsValid')) {
+                // Toggles display of share preprint modal
+                Ember.get(this, 'metrics')
+                    .trackEvent({
+                        category: 'button',
+                        action: 'click',
+                        label: 'Submit - Open Share Preprint Modal'
+                    });
+                this.toggleProperty('showModalSharePreprint');
+            } else {
+                Ember.get(this, 'metrics')
+                    .trackEvent({
+                        category: 'button',
+                        action: 'click',
+                        label: 'Submit - Display validation errors'
+                    });
+                this.set('attemptedSubmit', true);
+            }
         },
         savePreprint() {
             // Finalizes saving of preprint.  Publishes preprint and turns node public.

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1004,7 +1004,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
         /*
           Submit tab actions
          */
-        toggleSharePreprintModal() {
+        clickSubmit() {
             if (this.get('allSectionsValid')) {
                 // Toggles display of share preprint modal
                 Ember.get(this, 'metrics')

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -235,7 +235,7 @@
                                 </p>
                             {{/if}}
                             {{#if canResubmit}}
-                                <button class="btn btn-success btn-md m-t-md pull-right" disabled={{unless allSectionsValid true}} {{action 'toggleSharePreprintModal'}}>
+                                <button class="btn btn-success btn-md m-t-md pull-right" disabled={{unless allSectionsValid true}} {{action 'clickSubmit'}}>
                                     {{t "submit.body.edit.resubmit_button"}}
                                 </button>
                                 <div>
@@ -270,7 +270,7 @@
                                     <p class="text-danger">{{unless authorsValid (t "global.authors")}}</p>
                                 </span>
                             {{/if}}
-                            <button class="btn btn-success btn-md m-t-md pull-right" disabled={{showValidationErrors}} {{action 'toggleSharePreprintModal'}}>
+                            <button class="btn btn-success btn-md m-t-md pull-right" disabled={{showValidationErrors}} {{action 'clickSubmit'}}>
                                 {{t buttonLabel}}
                             </button>
                             <button class="btn btn-default btn-md m-t-md pull-right" {{action 'cancel'}}>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -261,7 +261,7 @@
                             </p>
                         {{/if}}
                         <div class="text-center">
-                            {{#unless allSectionsValid}}
+                            {{#if showValidationErrors}}
                                 <span id="validation-errors">
                                     <p class="m-t-md"><strong>{{t "submit.body.submit.invalid.description"}}</strong></p>
                                     <p class="text-danger">{{unless (and savedTitle savedFile) (t "submit.body.submit.invalid.upload")}}</p>
@@ -269,8 +269,8 @@
                                     <p class="text-danger">{{unless savedAbstract (t "submit.body.submit.invalid.basics")}}</p>
                                     <p class="text-danger">{{unless authorsValid (t "global.authors")}}</p>
                                 </span>
-                            {{/unless}}
-                            <button class="btn btn-success btn-md m-t-md pull-right" disabled={{unless allSectionsValid true}} {{action 'toggleSharePreprintModal'}}>
+                            {{/if}}
+                            <button class="btn btn-success btn-md m-t-md pull-right" disabled={{showValidationErrors}} {{action 'toggleSharePreprintModal'}}>
                                 {{t buttonLabel}}
                             </button>
                             <button class="btn btn-default btn-md m-t-md pull-right" {{action 'cancel'}}>

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -1014,11 +1014,25 @@ skip('highlightSuccessOrFailure', function() {
     //TODO
 });
 
-test('toggleSharePreprintModal', function(assert) {
+test('clickSubmit', function(assert) {
     const ctrl = this.subject();
-    assert.equal(ctrl.get('showModalSharePreprint'), false);
-    ctrl.send('toggleSharePreprintModal');
-    assert.equal(ctrl.get('showModalSharePreprint'), true);
+    assert.equal(ctrl.get('showModalSharePreprint'), false, 'showModalSharePreprint initial value');
+    assert.equal(ctrl.get('attemptedSubmit'), false, 'attemptedSubmit initial value');
+    assert.equal(ctrl.get('showValidationErrors'), false, 'showValidationErrors initial value');
+    assert.equal(ctrl.get('allSectionsValid'), false, 'allSectionsValid initial value');
+
+    ctrl.send('clickSubmit');
+
+    assert.equal(ctrl.get('showModalSharePreprint'), false, 'showModalSharePreprint after failed submit');
+    assert.equal(ctrl.get('attemptedSubmit'), true, 'attemptedSubmit after failed submit');
+    assert.equal(ctrl.get('showValidationErrors'), true, 'showValidationErrors after failed submit');
+    assert.equal(ctrl.get('allSectionsValid'), false, 'allSectionsValid after failed submit');
+
+    ctrl.set('allSectionsValid', true);
+    ctrl.send('clickSubmit');
+
+    assert.equal(ctrl.get('showModalSharePreprint'), true, 'showModalSharePreprint after valid submit');
+    assert.equal(ctrl.get('showValidationErrors'), false, 'showValidationErrors after valid submit');
 });
 
 skip('savePreprint', function() {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/MOD-88

## Purpose
Hide validation errors on the preprint submit page until the user tries submitting.
<!-- Describe the purpose of your changes -->

## Changes
Before clicking submit:
<img width="1300" alt="screen shot 2017-09-26 at 10 39 53 am" src="https://user-images.githubusercontent.com/6776190/30866690-f8362b90-a2a7-11e7-9034-c645fa32c388.png">

After clicking submit with validation errors, display errors and disable submit button until errors are fixed:
<img width="1305" alt="screen shot 2017-09-26 at 10 40 04 am" src="https://user-images.githubusercontent.com/6776190/30866709-02c904ce-a2a8-11e7-8f70-5451b5076a45.png">


<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->



